### PR TITLE
docs(readme): update for v0.2.0 — TCP adapter, CEL/Expr engine, parser pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ All expressions (filter, mapping, routing, template) share the same `data` conte
 | `data.id` | Message ULID |
 | `data.input` | Input type (`BESZEL`, `DOZZLE`, `GENERIC`, etc.) |
 | `data.payload` | Raw payload string |
-| `data.created_at` | Receive timestamp |
+| `data.createdAt` | Receive timestamp (RFC3339) |
 | `data.<field>` | Any field added via `mapping` expressions |
 
 **Filter** — boolean expression; message is dropped if `false`:


### PR DESCRIPTION
## Summary
- v0.2.0에서 구현 완료된 기능들을 README에 반영

## Motivation
v0.2.0 릴리즈(#21)에서 TCP 어댑터, CEL/Expr 표현식 엔진, 파서 파이프라인이 구현되었으나 README가 구버전 상태로 남아 있었음

## Changes
- Features 섹션: TCP, CEL/Expr 표현식 엔진 "planned" 제거 → 구현 완료로 업데이트
- Features 섹션: 파서 파이프라인 항목 신규 추가 (JSON/Form/XML/Logfmt/Regex)
- Configuration 예시: `expression.defaultEngine`, `parser`, TCP input, `template` map 포맷, `routing` 조건 반영
- Template Variables 섹션 → Expression Variables 섹션으로 교체 (filter/mapping/routing/template CEL/Expr 문법 예시 포함)
- API 섹션: TCP Inbound 항목 추가

## Test plan
- [ ] README 렌더링 확인